### PR TITLE
Create text field atom

### DIFF
--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,23 @@
+import { useState } from 'react';
 import './App.css';
-import { Button } from './components';
+import { Button, Input } from './components';
 import { Box } from '@mui/material';
 
 function App() {
+  const [feedback, setFeedback] = useState<string>('')
+
+  const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFeedback(event.target.value);
+  }
+
+  const sendFeedback = () => {
+    console.log(feedback);
+  }
+
   return (
     <Box>
-      <Button text='Send feedback'/>
+      <Input name='userFeedback' value={feedback} placeholder='Write your feedback here' onChange={handleOnChange}/>
+      <Button text='Send feedback' onClick={sendFeedback}/>
     </Box>
   );
 }

--- a/frontend/src/components/Atoms/Textfield/Input.test.tsx
+++ b/frontend/src/components/Atoms/Textfield/Input.test.tsx
@@ -1,0 +1,39 @@
+import {fireEvent, render} from "@testing-library/react";
+import {Input} from "./Input";
+
+describe("Input", () => {
+  it("renders", () => {
+    const conChange = jest.fn();
+
+    const {getByRole} = render(
+      <Input
+        name="test"
+        value="test"
+        placeholder="test"
+        onChange={conChange}
+        type="text"
+      />,
+    );
+
+    const input = getByRole("textbox");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("calls onChange", () => {
+    const conChange = jest.fn();
+
+    const {getByRole} = render(
+      <Input
+        name="test"
+        value="test"
+        placeholder="test"
+        onChange={conChange}
+        type="text"
+      />,
+    );
+
+    const input = getByRole("textbox");
+    fireEvent.change(input, {target: {value: "test1"}});
+    expect(conChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/Atoms/Textfield/Input.test.tsx
+++ b/frontend/src/components/Atoms/Textfield/Input.test.tsx
@@ -3,15 +3,14 @@ import {Input} from "./Input";
 
 describe("Input", () => {
   it("renders", () => {
-    const conChange = jest.fn();
+    const onChange = jest.fn();
 
     const {getByRole} = render(
       <Input
         name="test"
         value="test"
         placeholder="test"
-        onChange={conChange}
-        type="text"
+        onChange={onChange}
       />,
     );
 
@@ -20,20 +19,19 @@ describe("Input", () => {
   });
 
   it("calls onChange", () => {
-    const conChange = jest.fn();
+    const onChange = jest.fn();
 
     const {getByRole} = render(
       <Input
         name="test"
         value="test"
         placeholder="test"
-        onChange={conChange}
-        type="text"
+        onChange={onChange}
       />,
     );
 
     const input = getByRole("textbox");
     fireEvent.change(input, {target: {value: "test1"}});
-    expect(conChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/Atoms/Textfield/Input.tsx
+++ b/frontend/src/components/Atoms/Textfield/Input.tsx
@@ -1,0 +1,21 @@
+import {TextField} from "@mui/material";
+import InputProps from "./Types";
+import InputStyle from "./InputStyle";
+
+export const Input = ({
+  name,
+  value,
+  placeholder,
+  onChange,
+  extraStyles,
+}: InputProps) => {
+  return (
+    <TextField
+      name={name}
+      value={value}
+      placeholder={placeholder}
+      onChange={onChange}
+      sx={{...InputStyle, ...extraStyles}}
+    />
+  );
+};

--- a/frontend/src/components/Atoms/Textfield/InputStyle.ts
+++ b/frontend/src/components/Atoms/Textfield/InputStyle.ts
@@ -1,0 +1,12 @@
+const inputStyles = {
+    "&:hover": {
+      boxShadow: "xl",
+    },
+    border: "1px",
+    padding: 2,
+    borderRadius: "xl",
+    boxShadow: "lg",
+    width: "100%",
+  };
+  
+  export default inputStyles;

--- a/frontend/src/components/Atoms/Textfield/Types.ts
+++ b/frontend/src/components/Atoms/Textfield/Types.ts
@@ -1,5 +1,4 @@
 export default interface InputProps {
-    type: string;
     name: string;
     placeholder?: string;
     value?: string;

--- a/frontend/src/components/Atoms/Textfield/Types.ts
+++ b/frontend/src/components/Atoms/Textfield/Types.ts
@@ -1,0 +1,8 @@
+export default interface InputProps {
+    type: string;
+    name: string;
+    placeholder?: string;
+    value?: string;
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    extraStyles?: object;
+  }

--- a/frontend/src/components/Atoms/Textfield/index.ts
+++ b/frontend/src/components/Atoms/Textfield/index.ts
@@ -1,0 +1,1 @@
+export {Input} from "./Input";

--- a/frontend/src/components/Atoms/index.ts
+++ b/frontend/src/components/Atoms/index.ts
@@ -1,1 +1,2 @@
 export {Button} from "./Button";
+export {Input} from "./Textfield";


### PR DESCRIPTION
## Context
In the frontend, there are some components needed to emulate the performance app. Components like buttons, Textfields are needed. The solution is to use components to be able to make the app as similar as possible.
## Changes
- Add Textfield atom
- Add tests for the Textfield
- Add Textfield to the main page to be able to work together with the button atom
## Changes description
The objective for this changes is to create a reusable component following the Atomic design pattern.