### PR TITLE
Add OpenAI API endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from openai import OpenAI
+
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+app = FastAPI()
+
+client = OpenAI(
+    api_key = os.getenv("OPENAI_API_KEY")
+)
+
+class PromptRequest(BaseModel):
+    prompt: str
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello World"}
+
+@app.post("/chat/")
+async def chat_with_gpt(request: PromptRequest):
+    try:
+        response = client.chat.completions.create(
+            model= "gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {
+                    "role": "user",
+                    "content": request.prompt
+                }
+            ]
+        )
+        return {"response": response.choices[0].message.content}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello World"}
+
+def test_chat_with_gpt():
+    prompt = {"prompt": "Tell me a joke."}
+
+    response = client.post("/chat/", json=prompt)
+
+    assert response.status_code == 200
+    assert "response" in response.json()
+
+def test_chat_with_empty_prompt():
+    prompt = {"prompt": ""}
+
+    response = client.post("/chat/", json=prompt)
+
+    assert response.status_code == 200
+    assert "response" in response.json()


### PR DESCRIPTION
## Context
In the backend, there is a need to send data to the OpenAI API so that it can generate a proper feedback for the user
## Changes
- Expose a chat endpoint to send requests to the API
- Add basic OpenAI API implementation
- Add tests for the basic API implementation
## Changes description
The objective for this files is to create an endpoint to send data to the OpenAI model from the frontend.